### PR TITLE
fix error handling for reader to recover from disconnects

### DIFF
--- a/util/bfclf.py
+++ b/util/bfclf.py
@@ -47,8 +47,9 @@ log = logging.getLogger(__name__)
 class BroadcastFrameContactlessFrontend(ContactlessFrontend):
     # Modified code BEGIN
     def __init__(self, path=None, *, broadcast_enabled=False):
+        self.path = path
         self.broadcast_enabled = broadcast_enabled
-        super().__init__(path)
+        super().__init__(self.path)
 
     # Modified code END
 


### PR DESCRIPTION
- Allow hotplug of reader
- Ignore other type2 tags

-> There is still a "restart" of the reader required when a type2 tag was presented...

Details discussed in this issue: https://github.com/kormax/apple-home-key-reader/issues/3