### PR TITLE
Integrate CLF configuration retry logic

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -38,8 +38,10 @@ class Repository:
                     Issuer.from_dict(issuer)
                     for _, issuer in configuration.get("issuers", {}).items()
                 ]
-        except Exception as e:
-            log.exception(e)
+        except Exception:
+            log.exception(
+                f"Could not load Home Key configuration. Assuming that device is not yet configured..."
+            )
             pass
 
     def _save_state_to_file(self):

--- a/util/bfclf.py
+++ b/util/bfclf.py
@@ -38,10 +38,19 @@ from nfc.clf import (
     UnsupportedTargetError,
 )
 from nfc.tag import activate
+from nfc.tag.tt4 import Type4Tag
+
 
 from util.nfc import with_crc16a
 
+
 log = logging.getLogger(__name__)
+
+
+# Redeclaring just for cleaner imports elsewhere
+ISODEPTag = Type4Tag
+RemoteTarget = RemoteTarget
+activate = activate
 
 
 class BroadcastFrameContactlessFrontend(ContactlessFrontend):
@@ -49,7 +58,8 @@ class BroadcastFrameContactlessFrontend(ContactlessFrontend):
     def __init__(self, path=None, *, broadcast_enabled=False):
         self.path = path
         self.broadcast_enabled = broadcast_enabled
-        super().__init__(self.path)
+        # We send None so that we can try activating the reader later in a loop instead of throwing an exception right away
+        super().__init__(None)
 
     # Modified code END
 
@@ -180,4 +190,4 @@ class BroadcastFrameContactlessFrontend(ContactlessFrontend):
                     time.sleep(max(0, options.get("interval", 0.1) - elapsed))
 
 
-__all__ = ("BroadcastFrameContactlessFrontend", "RemoteTarget", "activate")
+__all__ = ("BroadcastFrameContactlessFrontend", "RemoteTarget", "ISODEPTag", "activate")

--- a/util/threads.py
+++ b/util/threads.py
@@ -1,0 +1,35 @@
+import functools
+import threading
+import time
+import logging
+
+
+def runner(
+    target, name: str, flag=lambda *args: True, *, delay=0, exception_delay=5
+):
+
+    self = target.__self__
+    @functools.wraps(target)
+    def function_(*args, **kwargs):
+        while flag(self):
+            time.sleep(delay)
+            try:
+                target(*args, **kwargs)
+            except Exception:
+                logging.exception(
+                    f"Unhandled exception in runner {name}. Continuing in {exception_delay} seconds"
+                )
+                time.sleep(exception_delay)
+
+    return function_
+
+
+def create_runner(
+    name: str, target: callable, flag: callable, *, start=False, **kwargs
+):
+    thread = threading.Thread(
+        name=name, target=runner(target=target, name=name, flag=flag, **kwargs)
+    )
+    if start:
+        thread.start()
+    return thread


### PR DESCRIPTION
This PR introduces changes proposed by @fussel132 that add CLF reconfiguration handling in cases where a connection has been interrupted, either because of a protocol error, or due to physical connection being disturbed.

