### PR TITLE
Monkey patch PN532 init method to disable baudrate modification

### DIFF
--- a/service.py
+++ b/service.py
@@ -1,11 +1,8 @@
 import base64
-import functools
 import logging
-import threading
 import time
 import os
 from operator import attrgetter
-from typing import Optional
 
 from entity import (
     Issuer,
@@ -175,7 +172,7 @@ class Service:
         if self.repository.get_reader_private_key() in (None, b""):
             raise Exception("Device is not configured via HAP. NFC inactive")
 
-        log.exception(f"Connecting to the NFC reader...")
+        log.exception("Connecting to the NFC reader...")
 
         self.clf.device = None
         self.clf.open(self.clf.path)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, lint
+envlist = py39, py310, py311, py312, lint
 
 
 [testenv]

--- a/util/threads.py
+++ b/util/threads.py
@@ -9,6 +9,7 @@ def runner(
 ):
 
     self = target.__self__
+
     @functools.wraps(target)
     def function_(*args, **kwargs):
         while flag(self):


### PR DESCRIPTION
This PR introduces following changes:
- Monkey-patch nfcpy pn532 init method to disable baudrate negotiation
- Add py312 as possible target
- Apply black code formatting pass

As a result of this PR, users should stop having issues when their NFC reader when it disconnects abruptly, or when closing the application.